### PR TITLE
Removed possibility circumventing the filter by using spaces in between swear-word

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -79,7 +79,7 @@ function filter.mute(name, duration)
 		minetest.set_player_privs(name, privs)
 	end
 
-	minetest.chat_send_player(name, "Watch your language! You have been temporarily muted")
+	minetest.chat_send_player(name, minetest.colorize("#FF8C00","Watch your language! You have been temporarily muted"))
 
 	muted[name] = true
 
@@ -87,7 +87,7 @@ function filter.mute(name, duration)
 		muted[name] = nil
 		local privs = minetest.get_player_privs(name)
 		if privs.shout == false then
-			minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")		
+			minetest.chat_send_player(name, minetest.colorize("#FF8C00","Chat privilege reinstated. Please do not abuse chat."))		
 			privs.shout = true
 			minetest.set_player_privs(name, privs)
 		end

--- a/init.lua
+++ b/init.lua
@@ -85,11 +85,12 @@ function filter.mute(name, duration)
 
 	minetest.after(duration * 60, function()
 		muted[name] = nil
-		minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")
-
 		local privs = minetest.get_player_privs(name)
-		privs.shout = true
-		minetest.set_player_privs(name, privs)
+		if privs.shout == false then
+			minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")		
+			privs.shout = true
+			minetest.set_player_privs(name, privs)
+		end
 	end)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -62,8 +62,9 @@ function filter.register_on_violation(func)
 end
 
 function filter.check_message(name, message)
+	local trimmed_msg = message:gsub(" ","")
 	for _, w in ipairs(words) do
-		if string.find(message:lower(), "%f[%a]" .. w .. "%f[%A]") then
+		if string.find(trimmed_msg:lower(), "%f[%a]" .. w .. "%f[%A]") then
 			return false
 		end
 	end


### PR DESCRIPTION
## Proposed changes
- Now all chat messages will be _stripped of all white-spaces before being scanned_ for any blacklisted words. This makes it impossible to circumvent the mod by adding spaces in between the aforementioned blacklisted words.
- An additional priv check will be performed, and player will be "un-muted" _only if_ shout hasn't already been granted by other means (manually, by other mods, or if it's irrevokable)
- Now, player muted and un-muted messages will be highlighted for better visibility.

Note: All proposed changes have been tested and they work successfully.