### PR TITLE
Added priv check before un-muting player

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -78,11 +78,12 @@ function filter.mute(name, duration)
 
 	minetest.after(duration * 60, function()
 		muted[name] = nil
-		minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")
-
-		local privs = minetest.get_player_privs(name)
-		privs.shout = true
-		minetest.set_player_privs(name, privs)
+ 		local privs = minetest.get_player_privs(name)
+		if privs.shout == false then
+			minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")		
+			privs.shout = true
+			minetest.set_player_privs(name, privs)
+		end
 	end)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -79,7 +79,7 @@ function filter.mute(name, duration)
 		minetest.set_player_privs(name, privs)
 	end
 
-	minetest.chat_send_player(name, "Watch your language! You have been temporarily muted")
+	minetest.chat_send_player(name, minetest.colorize("#FF8C00","Watch your language! You have been temporarily muted"))
 
 	muted[name] = true
 
@@ -87,7 +87,7 @@ function filter.mute(name, duration)
 		muted[name] = nil
 		local privs = minetest.get_player_privs(name)
 		if privs.shout == false then
-			minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")		
+			minetest.chat_send_player(name, minetest.colorize("#FF8C00","Chat privilege reinstated. Please do not abuse chat."))		
 			privs.shout = true
 			minetest.set_player_privs(name, privs)
 		end

--- a/init.lua
+++ b/init.lua
@@ -85,11 +85,12 @@ function filter.mute(name, duration)
 
 	minetest.after(duration * 60, function()
 		muted[name] = nil
-		minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")
-
 		local privs = minetest.get_player_privs(name)
-		privs.shout = true
-		minetest.set_player_privs(name, privs)
+		if privs.shout == false then
+			minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")		
+			privs.shout = true
+			minetest.set_player_privs(name, privs)
+		end
 	end)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -1,9 +1,6 @@
-
 --[[
-
 	Copyright 2017-8 Auke Kok <sofar@foo-projects.org>
 	Copyright 2018 rubenwardy <rw@rubenwardy.com>
-
 	Permission is hereby granted, free of charge, to any person obtaining
 	a copy of this software and associated documentation files (the
 	"Software"), to deal in the Software without restriction, including
@@ -11,10 +8,8 @@
 	distribute, sublicense, and/or sell copies of the Software, and to
 	permit persons to whom the Software is furnished to do so, subject
 	to the following conditions:
-
 	The above copyright notice and this permission notice shall be included
 	in all copies or substantial portions of the Software.
-
 	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
 	KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 	WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22,7 +17,6 @@
 	LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 	OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 	WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 ]]--
 
 filter = { registered_on_violations = {} }
@@ -62,9 +56,8 @@ function filter.register_on_violation(func)
 end
 
 function filter.check_message(name, message)
-	local trimmed_msg = message:gsub(" ","")
 	for _, w in ipairs(words) do
-		if string.find(trimmed_msg:lower(), "%f[%a]" .. w .. "%f[%A]") then
+		if string.find(message:lower(), "%f[%a]" .. w .. "%f[%A]") then
 			return false
 		end
 	end
@@ -79,18 +72,17 @@ function filter.mute(name, duration)
 		minetest.set_player_privs(name, privs)
 	end
 
-	minetest.chat_send_player(name, minetest.colorize("#FF8C00","Watch your language! You have been temporarily muted"))
+	minetest.chat_send_player(name, "Watch your language! You have been temporarily muted")
 
 	muted[name] = true
 
 	minetest.after(duration * 60, function()
 		muted[name] = nil
+		minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")
+
 		local privs = minetest.get_player_privs(name)
-		if privs.shout == false then
-			minetest.chat_send_player(name, minetest.colorize("#FF8C00","Chat privilege reinstated. Please do not abuse chat."))		
-			privs.shout = true
-			minetest.set_player_privs(name, privs)
-		end
+		privs.shout = true
+		minetest.set_player_privs(name, privs)
 	end)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -62,8 +62,9 @@ function filter.register_on_violation(func)
 end
 
 function filter.check_message(name, message)
+	local trimmed_msg = message:gsub(" ","")
 	for _, w in ipairs(words) do
-		if string.find(message:lower(), "%f[%a]" .. w .. "%f[%A]") then
+		if string.find(trimmed_msg:lower(), "%f[%a]" .. w .. "%f[%A]") then
 			return false
 		end
 	end


### PR DESCRIPTION
Un-mutes a player only if their shout priv hasn't been granted already (e.g. by other mods, manually, or if it's irrevokable)

@sofar - unfortunately, I pushed all the commits from the previous PR into the master branch, so I had to make a revert commit.