### PR TITLE
Added priv-check before un-muting player

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -83,10 +83,14 @@ function filter.mute(name, duration)
 	muted[name] = true
 
 	minetest.after(duration * 60, function()
+		privs = minetest.get_player_privs(name)
+		if privs.shout==true then
+			return
+		end
+			
 		muted[name] = nil
 		minetest.chat_send_player(name, "Chat privilege reinstated. Please do not abuse chat.")
 
-		local privs = minetest.get_player_privs(name)
 		privs.shout = true
 		minetest.set_player_privs(name, privs)
 	end)


### PR DESCRIPTION
### Cause
- Player is not mutable in singleplayer since shout is an unrevokable priv.

### Effect
- Player ends up being "unmuted" (in spite of not having been muted) after the specified duration.

## Proposed Changes
- Muted player's shout priv is rechecked before re-granting the same.