### PR TITLE
Add support for custom filters

### DIFF
--- a/filters.lua
+++ b/filters.lua
@@ -1,0 +1,58 @@
+-- Words filter
+filter.register_filter("words", function(name, message)
+	for _, w in ipairs(filter.assets["words"].words) do
+		if string.find(message:lower(), "%f[%a]" .. w .. "%f[%A]") then
+			return "Watch your language!"
+		end
+	end
+end)
+
+-- Initialize words list
+filter.register_on_init(function()
+	local sw = s:get_string("words")
+	if sw and sw ~= "" then
+		filter.assets["words"].words = minetest.parse_json(sw)
+	end
+
+	if #filter.assets["words"].words == 0 then
+		local words = {}
+		local file = io.open(filepath, "r")
+		if file then
+			for line in file:lines() do
+				line = line:trim()
+				if line ~= "" then
+					words[#words + 1] = line:trim()
+				end
+			end
+			filter.assets["words"].words = words
+		end
+	end
+end)
+
+-- Words filter sub-command
+filter.register_chatcommand("words", {
+	description = "Usage: /filter words <add|remove|list> [<word>]",
+	func = function(cmd)
+		local words = filter.assets["words"].words
+		if cmd == "list" then
+			return true, #words .. " words: " .. table.concat(words, ", ")
+		elseif cmd == "add" then
+			table.insert(filter.assets["words"].words, param)
+			filter.storage:set_string("words", minetest.write_json(words))
+			filter.assets["words"].words = words
+			return true, "Added \"" .. val .. "\"."
+		elseif cmd == "remove" then
+			for i, w in ipairs(words) do
+				if w == param then
+					table.remove(words, i)
+					filter.storage:set_string("words", minetest.write_json(words))
+					filter.assets["words"].words = words
+					return true, "Removed \"" .. param .. "\"."
+				end
+			end
+			return false, "\"" .. param .. "\" not found in list."
+		else
+			return false, "Invalid option. See /help filter"
+		end
+	end
+})

--- a/readme.md
+++ b/readme.md
@@ -1,38 +1,49 @@
 # filter mod
 
-This mod adds a simple chat filter. There is no default word list,
-and adding words to the filter list is done through the `/filter`
-chat command. You need the `server` priv to use the chat command.
+This mod adds a chat filter API that can be used to register custom
+chat filters. As of now a bad words filter has been implemented. There
+is no default word list, and adding words to the filter list is done
+through the `/word_filter` chat command, which requires `server` priv.
 
-The `/filter` chat command can `add`, `remove` or `list` words. The
+The `/word_filter` chat command can `add`, `remove` or `list` words. The
 words are stored in `mod_storage`, which means that this mod requires
 0.4.16 or above to function.
 
-If a player speaks a word that is listed in the filter list, they are
-muted for 1 minute. After that, their `shout` privilege is restored.
-If they leave, their `shout` privilege is still restored, but only after
-the time expires, not before.
+If a player triggers a filter, they are muted for 1 minute. After that,
+their `shout` privilege is restored. If they leave, their `shout`
+privilege is still restored, but only after the time expires, not before.
 
 ## API
 
+### Custom filter registration
+
+* `filter.register_filter(name, func(playername, message))`
+  * Takes a name and a two-parameter function
+  * `name` is the name of the filter, which is currently unused, except
+    for indexing.
+  * `playername` and `message` hold the name of the player and the
+    message they sent, respectively.
+  * `func` should return a relevant warning when triggered. e.g.
+    "Watch your language!", and `nil` when message has passed the check.
+
 ### Callbacks
 
-* filter.register_on_violation(func(name, message, violations))
-	* Violations is the value of the player's violation counter - which is
-	  incremented on a violation, and halved every 10 minutes.
-	* Return true if you've handled the violation. No more callbacks will be
-	  executation, and the default behaviour (warning/mute/kick) on violation
-	  will be skipped.
+* `filter.register_on_violation(func(name, message, violations))`
+  * `violations` is the value of the player's violation counter - which is
+    incremented on a violation, and halved every 10 minutes.
+  * Return `true` if you've handled the violation. No more callbacks will be
+    executation, and the default behaviour (warning/mute/kick) on violation
+    will be skipped.
 
 ### Methods
 
-* filter.import_file(path)
-	* Input bad words from a file (`path`) where each line is a new word.
-* filter.check_message(name, message)
-	* Checks message for violation. Returns true if okay, false if bad.
-	  If it returns false, you should cancel the sending of the message and
-	  call filter.on_violation()
-* filter.on_violation(name, message)
-	* Increments violation count, runs callbacks, and punishes the players.
-* filter.mute(name, duration)
-* filter.show_warning_formspec(name)
+* `filter.import_file(path)`
+  * Input bad words from a file (`path`) where each line is a new word.
+* `filter.check_message(name, message)`
+  * Checks message for violation. Returns `true` if bad, `false` if ok.
+    If it returns true, the message is not sent `filter.on_violation` is
+    called.
+* `filter.on_violation(name, message)`
+  * Increments violation count, runs callbacks, and punishes the players.
+* `filter.mute(name, duration)`
+* `filter.show_warning_formspec(name)`


### PR DESCRIPTION
- Added a `registered_filters` table and a `register_filter` method which registers a custom filter.
- All filters are invoked with params `playername` and `message` in `check_message`.
- Since each filter has its own warning, filters return the warning itself when triggered.
- `check_message` concats all the warnings (if multiple filters were triggered) separated by a new-line.
- Mute and kick messages are more generic.

**Tested**. Everything works except for the new-line separation of warnings, which requires an open engine PR (minetest/minetest#7728) to be merged, after which it could make use of `minetest.wrap_text` while preserving newlines.

I've already implemented a spam filter, which is triggered when the same message has been repeated thrice. I'll make a separate PR for that once this has been merged.